### PR TITLE
fix: improve BLE disconnect handling and prevent zombie connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ WS_HOST=127.0.0.1 npx @trakrf/web-ble-bridge
 # Options: debug, info, warn, error
 # Also supports: verbose, trace (maps to debug), warning (maps to info)
 LOG_LEVEL=info npx @trakrf/web-ble-bridge
+
+# Set BLE device recovery delay in milliseconds (default: 1000)
+# Time to wait after disconnect before allowing new connections
+# Protects devices from rapid reconnection attempts
+BLE_RECOVERY_DELAY=2000 npx @trakrf/web-ble-bridge
 ```
 
 **Log Levels:**

--- a/README.md
+++ b/README.md
@@ -67,10 +67,15 @@ WS_HOST=127.0.0.1 npx @trakrf/web-ble-bridge
 # Also supports: verbose, trace (maps to debug), warning (maps to info)
 LOG_LEVEL=info npx @trakrf/web-ble-bridge
 
-# Set BLE device recovery delay in milliseconds (default: 1000)
-# Time to wait after disconnect before allowing new connections
-# Protects devices from rapid reconnection attempts
-BLE_RECOVERY_DELAY=2000 npx @trakrf/web-ble-bridge
+# Advanced BLE timing configuration (milliseconds)
+# Override platform-specific defaults for your hardware
+# Note: Default values vary by platform (macOS/Windows/Linux)
+BLE_CONNECTION_STABILITY=0      # Delay after connection before service discovery
+BLE_PRE_DISCOVERY_DELAY=0       # Additional delay before service discovery
+BLE_NOBLE_RESET_DELAY=1000      # Delay after Noble reset before operations
+BLE_SCAN_TIMEOUT=15000          # Maximum time to scan for devices
+BLE_CONNECTION_TIMEOUT=15000    # Maximum time to establish connection
+BLE_DISCONNECT_COOLDOWN=2000    # Recovery time after disconnect (critical for device health)
 ```
 
 **Log Levels:**

--- a/src/noble-transport.ts
+++ b/src/noble-transport.ts
@@ -2,7 +2,7 @@ import noble from '@stoprocent/noble';
 import { LogLevel } from './utils.js';
 
 // Increase max listeners to prevent warnings during rapid connections
-noble.setMaxListeners(20);
+noble.setMaxListeners(50);
 
 // Global cleanup to ensure Noble doesn't keep process alive
 export async function cleanupNoble(): Promise<void> {

--- a/src/start-server.ts
+++ b/src/start-server.ts
@@ -11,8 +11,25 @@ console.log('🚀 Starting WebSocket-to-BLE Bridge Server');
 console.log(`   Port: ${port}`);
 console.log(`   Host: ${host}`);
 console.log(`   Log level: ${logLevel}`);
-console.log(`   BLE recovery delay: ${process.env.BLE_RECOVERY_DELAY || '1000'}ms`);
 console.log('   Device-agnostic - UUIDs provided by client');
+
+// Show any BLE timing overrides
+const bleOverrides = [
+  'BLE_CONNECTION_STABILITY',
+  'BLE_PRE_DISCOVERY_DELAY', 
+  'BLE_NOBLE_RESET_DELAY',
+  'BLE_SCAN_TIMEOUT',
+  'BLE_CONNECTION_TIMEOUT',
+  'BLE_DISCONNECT_COOLDOWN'
+].filter(key => process.env[key]);
+
+if (bleOverrides.length > 0) {
+  console.log('   BLE timing overrides:');
+  bleOverrides.forEach(key => {
+    console.log(`     ${key}: ${process.env[key]}ms`);
+  });
+}
+
 console.log('   Press Ctrl+C to stop\n');
 
 const server = new BridgeServer(logLevel);

--- a/src/start-server.ts
+++ b/src/start-server.ts
@@ -11,6 +11,7 @@ console.log('🚀 Starting WebSocket-to-BLE Bridge Server');
 console.log(`   Port: ${port}`);
 console.log(`   Host: ${host}`);
 console.log(`   Log level: ${logLevel}`);
+console.log(`   BLE recovery delay: ${process.env.BLE_RECOVERY_DELAY || '1000'}ms`);
 console.log('   Device-agnostic - UUIDs provided by client');
 console.log('   Press Ctrl+C to stop\n');
 


### PR DESCRIPTION
## Summary
- Fixes device getting stuck in disconnecting state during tests
- Prevents zombie BLE connections with enhanced detection and cleanup
- Improves error handling in connect() to always clean up on failure

## Key Changes

### Disconnect State Management
- Added early return if already disconnecting to prevent concurrent disconnect attempts
- Fixed missing await on disconnect() in zombie check function
- Made checkForZombieConnections async to properly await disconnect

### Error Handling
- Enhanced connect() error handling to always disconnect peripheral on failure
- Clears all references (peripheral, writeChar, notifyChar) on error
- Ensures state is reset to DISCONNECTED on any connection error

### Zombie Detection (Debugging)
- Reduced zombie check interval to 5 seconds for debugging
- Added detailed logging when zombie is detected (state, device name, client counts)
- Nuclear option to null out transport if disconnect fails

## Test Results
- Single connection tests pass reliably
- Device remains available between test runs
- Stress tests still have some issues with rapid connects/disconnects (needs further investigation)

## Related Issues
Addresses test timeout issues preventing npm publish

🤖 Generated with [Claude Code](https://claude.ai/code)